### PR TITLE
Fix geth version

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -11,3 +11,8 @@ optimism_package:
         builder_port: "9997"
       additional_services:
         - blockscout
+
+ethereum_package:
+  participants:
+    - el_type: geth
+      el_image: ethereum/client-go:v1.14.13


### PR DESCRIPTION
By default, the `optimism-package` config uses the latest image of geth for the L1 (`ethereum/client-go:latest`). A few days ago, they released a new version (1.15.0) that introduces some breaking changes: https://github.com/ethereum/go-ethereum/releases/tag/v1.15.0.

This PR pins the version to a stable one:
- For Us being able to develop if we happen to start everything from scratch.
- For newcomers to avoid having issues running everything from scratch.