### PR TITLE
Use bash shell in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ BOP_NODE_PORT=$(shell kurtosis service inspect based-op op-cl-2-op-node-op-geth-
 BOP_EL_PORT=$(shell kurtosis service inspect based-op op-el-2-op-geth-op-node-op-kurtosis | grep 'rpc: 8545/tcp -> http://127.0.0.1:' | cut -d : -f 4)
 PORTAL_PORT=$(shell kurtosis service inspect based-op op-based-portal-1-op-kurtosis | grep 'rpc: 8541/tcp -> http://127.0.0.1:' | cut -d : -f 4)
 
+# Some servers default to executing shell scripts below with /bin/sh, we set bash to make sure our bash syntax works
+SHELL := /bin/bash
+
 # Recipes
 
 help: ## 📚 Show help for each of the Makefile recipes


### PR DESCRIPTION
we use bash syntax in our Makefile, but some servers may execute with /bin/sh shell by default.

on ubuntu 24.04, the latest LTS, the makefile seems to blow up when installing deps because it relies on bash syntax but that server uses sh (dash) by default.

this change forces use of bash and makes the Makefile run again on our server.

i'm a little weary of this breaking other systems where people maybe only have zsh or don't have bash installed in /bin/bash but probably fine. if you don't want to take the risk feel free to close as wont-fix.