### PR TITLE
Registry fetch fix + overseer fixes + syncmode fix 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -470,10 +470,10 @@ FOLLOWER_NODE_HOST?=http://localhost
 BLOCK_NUMBER?=$(shell echo $$(( $$(cast block-number --rpc-url http://localhost:$(BOP_EL_PORT)) + 1 )))
 DUMMY_RICH_WALLET_PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 DUMMY_TX=$(shell cast mktx --rpc-url  $(FOLLOWER_NODE_HOST):$(BOP_EL_PORT) --private-key $(DUMMY_RICH_WALLET_PRIVATE_KEY) --value 1 0x7DDcC7c49D562997A68C98ae7Bb62eD1E8E4488a | xxd -r -p | base64)
-PORTAL_PORT?=8080
+LOCAL_GETH_PORT?=8645
 
 test-tx:
-	cast send --rpc-url  http://127.0.0.1:$(PORTAL_PORT) --private-key $(DUMMY_RICH_WALLET_PRIVATE_KEY) --value 1 0x7DDcC7c49D562997A68C98ae7Bb62eD1E8E4488a
+	cast send --rpc-url  http://0.0.0.0:$(LOCAL_GETH_PORT) --private-key $(DUMMY_RICH_WALLET_PRIVATE_KEY) --value 1 0x7DDcC7c49D562997A68C98ae7Bb62eD1E8E4488a
 
 test-frag:
 	curl --request POST   --url $(FOLLOWER_NODE_HOST):$(BOP_NODE_PORT) --header 'Content-Type: application/json' \

--- a/based/bin/overseer/src/collections.rs
+++ b/based/bin/overseer/src/collections.rs
@@ -373,6 +373,7 @@ impl<T: Default + Clone + HasKey> KeyedCircularBuffer<T> {
     pub fn new(size: usize) -> Self {
         Self { data: CircularBuffer::new(size), ids: HashMap::new(), count: 0 }
     }
+
 }
 
 impl<T: HasKey> KeyedCircularBuffer<T> {
@@ -400,6 +401,10 @@ impl<T: HasKey> KeyedCircularBuffer<T> {
         self.data.iter()
     }
 
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.count == 0

--- a/based/bin/overseer/src/collections.rs
+++ b/based/bin/overseer/src/collections.rs
@@ -373,7 +373,6 @@ impl<T: Default + Clone + HasKey> KeyedCircularBuffer<T> {
     pub fn new(size: usize) -> Self {
         Self { data: CircularBuffer::new(size), ids: HashMap::new(), count: 0 }
     }
-
 }
 
 impl<T: HasKey> KeyedCircularBuffer<T> {
@@ -401,10 +400,6 @@ impl<T: HasKey> KeyedCircularBuffer<T> {
         self.data.iter()
     }
 
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.data.len()
-    }
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.count == 0

--- a/based/bin/overseer/src/data/frag.rs
+++ b/based/bin/overseer/src/data/frag.rs
@@ -40,6 +40,7 @@ impl FragData {
 
     pub fn to_block_table_row(&self) -> Vec<Text<'_>> {
         let Frag::SorterStart { seq, .. } = &self.updates[0].1 else {
+            tracing::warn!("strange frag setup");
             return vec![];
         };
         let (payment, gas_used, n_txs) = self.frag_stats().unwrap_or_default();

--- a/based/crates/common/src/config.rs
+++ b/based/crates/common/src/config.rs
@@ -40,8 +40,8 @@ pub struct GatewayArgs {
     #[arg(long = "eth_client.url", default_value = "http://localhost:8545")]
     pub eth_client_url: Url,
     /// Url to the root peer gossip node
-    #[arg(long = "gossip.root_peer_url")]
-    pub gossip_root_peer_url: Option<Url>,
+    #[arg(long = "gossip.root_peer_url", default_value = "http://localhost:8547")]
+    pub gossip_root_peer_url: Url,
     /// Gossip to sign frag messages
     #[arg(long = "gossip.signer_private_key")]
     pub gossip_signer_private_key: Option<B256>,

--- a/based/crates/pool/src/transaction/pool.rs
+++ b/based/crates/pool/src/transaction/pool.rs
@@ -153,7 +153,7 @@ impl TxPool {
     /// This gets called in two places:
     /// 1) When we sync a new block.
     /// 2) When we commit a new Frag.
-    pub fn handle_new_block<'a, Db: DatabaseRead>(
+    pub fn handle_new_block<Db: DatabaseRead>(
         &mut self,
         base_fee: u64,
         db: &DBFrag<Db>,

--- a/based/crates/pool/src/transaction/pool.rs
+++ b/based/crates/pool/src/transaction/pool.rs
@@ -18,7 +18,7 @@ pub struct TxPool {
     /// maps an eoa to all pending txs
     pool_data: HashMap<Address, TxList>,
     /// Current list of all simulated mineable txs in the pool
-    active_txs: Active,
+    pub active_txs: Active,
 }
 
 impl TxPool {
@@ -39,12 +39,12 @@ impl TxPool {
         base_fee: u64,
         syncing: bool,
         sim_sender: Option<&SendersSpine<Db>>,
-    ) {
+    ) -> bool {
         let state_nonce = db.get_nonce(new_tx.sender()).expect("handle failed db");
         let nonce = new_tx.nonce();
         // check nonce is valid
         if nonce < state_nonce {
-            return;
+            return false;
         }
 
         let is_next_nonce = nonce == state_nonce;
@@ -57,7 +57,7 @@ impl TxPool {
                 // above where we didn't return
                 if tx_list.get_effective_price_for_nonce(&nonce, base_fee) > new_tx.effective_gas_price(Some(base_fee))
                 {
-                    return;
+                    return false;
                 }
                 tx_list.put(new_tx.clone());
 
@@ -92,6 +92,7 @@ impl TxPool {
                 self.pool_data.insert(tx_list.sender(), tx_list);
             }
         }
+        true
     }
 
     /// Validates simualted tx. If valid, fetch its TxList and save the new [SimulatedTxList] to `active_txs`.
@@ -152,19 +153,13 @@ impl TxPool {
     /// This gets called in two places:
     /// 1) When we sync a new block.
     /// 2) When we commit a new Frag.
-    pub fn handle_new_block<'a, Db: DatabaseRead, T: TransactionSenderInfo + 'a>(
+    pub fn handle_new_block<'a, Db: DatabaseRead>(
         &mut self,
-        mined_txs: impl Iterator<Item = &'a T>,
         base_fee: u64,
         db: &DBFrag<Db>,
         syncing: bool,
         sim_sender: Option<&SendersSpine<Db>>,
-        telemetry_producer: &mut Producer<TelemetryUpdate>,
     ) {
-        // Completely wipe active txs as they may contain valid nonces with out of date sim results.
-        self.active_txs.clear();
-        self.remove_mined_txs(mined_txs, telemetry_producer);
-
         // If enabled, fill the active list with non-simulated txs and send off the first tx for each sender to
         // simulator.
         if !syncing {

--- a/based/crates/rpc/src/gossiper.rs
+++ b/based/crates/rpc/src/gossiper.rs
@@ -4,13 +4,13 @@ use reqwest::blocking::{Client, ClientBuilder};
 use tracing::{error, info};
 
 pub struct Gossiper {
-    target_rpc: Option<Url>,
+    target_rpc: Url,
     client: Client,
     signer: ECDSASigner,
 }
 
 impl Gossiper {
-    pub fn new(target_rpc: Option<Url>, signer: Option<ECDSASigner>) -> Self {
+    pub fn new(target_rpc: Url, signer: Option<ECDSASigner>) -> Self {
         let client = ClientBuilder::new()
             .timeout(std::time::Duration::from_secs(10))
             .build()
@@ -22,13 +22,9 @@ impl Gossiper {
     }
 
     fn gossip(&self, msg: p2p::VersionedMessage) {
-        let Some(url) = self.target_rpc.as_ref().cloned() else {
-            return;
-        };
-
         let payload = msg.to_json(&self.signer);
 
-        let Ok(res) = self.client.post(url).json(&payload).send() else {
+        let Ok(res) = self.client.post(self.target_rpc.clone()).json(&payload).send() else {
             tracing::error!("couldn't send {}", payload);
             return;
         };

--- a/based/crates/sequencer/src/context.rs
+++ b/based/crates/sequencer/src/context.rs
@@ -307,20 +307,17 @@ impl<Db: DatabaseRead + Database<Error: Into<ProviderError> + Display>> Sequence
             frag_seq.txs.len(),
             mgas / frag_seq.start_t.elapsed().as_secs()
         );
-        (
-            seal,
-            OpExecutionPayloadEnvelopeV3 {
-                execution_payload: ExecutionPayloadV3 {
-                    payload_inner: ExecutionPayloadV2 { payload_inner: v1, withdrawals: vec![] },
-                    blob_gas_used: 0,
-                    excess_blob_gas: 0,
-                },
-                block_value: frag_seq.payment.to(),
-                blobs_bundle: BlobsBundleV1::new(vec![]),
-                should_override_builder: false,
-                parent_beacon_block_root: parent_beacon_block_root.expect("should always be set"),
+        (seal, OpExecutionPayloadEnvelopeV3 {
+            execution_payload: ExecutionPayloadV3 {
+                payload_inner: ExecutionPayloadV2 { payload_inner: v1, withdrawals: vec![] },
+                blob_gas_used: 0,
+                excess_blob_gas: 0,
             },
-        )
+            block_value: frag_seq.payment.to(),
+            blobs_bundle: BlobsBundleV1::new(vec![]),
+            should_override_builder: false,
+            parent_beacon_block_root: parent_beacon_block_root.expect("should always be set"),
+        })
     }
 }
 impl<Db: DatabaseWrite + DatabaseRead> SequencerContext<Db> {

--- a/based/crates/sequencer/src/context.rs
+++ b/based/crates/sequencer/src/context.rs
@@ -167,14 +167,15 @@ impl<Db: DatabaseRead + Database<Error: Into<ProviderError> + Display>> Sequence
             self.deposits.push_back(tx);
             return;
         }
-        TelemetryUpdate::send(tx.uuid, tx.to_added_to_pool_telemetry(), &mut self.telemetry);
-        self.tx_pool.handle_new_tx(
+        if self.tx_pool.handle_new_tx(
             tx.clone(),
             self.shared_state.as_ref(),
             self.as_ref().basefee.to(),
             false,
             self.config.simulate_tof_in_pools.then_some(senders),
-        );
+        ) {
+            TelemetryUpdate::send(tx.uuid, tx.to_added_to_pool_telemetry(), &mut self.telemetry);
+        }
     }
 
     /// Processes a new block from the sequencer by:
@@ -306,17 +307,20 @@ impl<Db: DatabaseRead + Database<Error: Into<ProviderError> + Display>> Sequence
             frag_seq.txs.len(),
             mgas / frag_seq.start_t.elapsed().as_secs()
         );
-        (seal, OpExecutionPayloadEnvelopeV3 {
-            execution_payload: ExecutionPayloadV3 {
-                payload_inner: ExecutionPayloadV2 { payload_inner: v1, withdrawals: vec![] },
-                blob_gas_used: 0,
-                excess_blob_gas: 0,
+        (
+            seal,
+            OpExecutionPayloadEnvelopeV3 {
+                execution_payload: ExecutionPayloadV3 {
+                    payload_inner: ExecutionPayloadV2 { payload_inner: v1, withdrawals: vec![] },
+                    blob_gas_used: 0,
+                    excess_blob_gas: 0,
+                },
+                block_value: frag_seq.payment.to(),
+                blobs_bundle: BlobsBundleV1::new(vec![]),
+                should_override_builder: false,
+                parent_beacon_block_root: parent_beacon_block_root.expect("should always be set"),
             },
-            block_value: frag_seq.payment.to(),
-            blobs_bundle: BlobsBundleV1::new(vec![]),
-            should_override_builder: false,
-            parent_beacon_block_root: parent_beacon_block_root.expect("should always be set"),
-        })
+        )
     }
 }
 impl<Db: DatabaseWrite + DatabaseRead> SequencerContext<Db> {
@@ -337,17 +341,14 @@ impl<Db: DatabaseWrite + DatabaseRead> SequencerContext<Db> {
         self.parent_header = block.header.clone();
         self.parent_hash = block.hash_slow();
 
+        // Completely wipe active txs as they may contain valid nonces with out of date sim results.
+        self.tx_pool.active_txs.clear();
+        self.tx_pool.remove_mined_txs(block.body.transactions.iter(), &mut self.telemetry);
+
         if let Some(base_fee) = block.base_fee_per_gas {
             self.base_fee = base_fee;
 
-            self.tx_pool.handle_new_block(
-                block.body.transactions.iter(),
-                base_fee,
-                self.shared_state.as_ref(),
-                false,
-                None,
-                &mut self.telemetry,
-            );
+            self.tx_pool.handle_new_block(base_fee, self.shared_state.as_ref(), false, None);
         }
 
         blocks_to_fetch

--- a/based/crates/sequencer/src/sorting/sorting_data.rs
+++ b/based/crates/sequencer/src/sorting/sorting_data.rs
@@ -141,7 +141,7 @@ impl<Db> SortingData<Db> {
             txs: vec![],
             start_t: Instant::now(),
             telemetry: Default::default(),
-            uuid: Uuid::new_v4(),
+            uuid,
             telemetry_producer,
         }
     }

--- a/follower_node/compose.yml
+++ b/follower_node/compose.yml
@@ -73,6 +73,7 @@ services:
       - --rpc.enable-based 
       - --registry=$PORTAL
       - --p2p.bootnodes=$MAIN_OP_NODE_ENR
+      - --syncmode=execution-layer
     volumes:
       - ./data/node:/data/op-node
       - ./config:/config

--- a/optimism/op-node/node/node.go
+++ b/optimism/op-node/node/node.go
@@ -263,6 +263,7 @@ func (n *OpNode) initRegistry(ctx context.Context, cfg *Config) error {
 			if err := n.registrySource.FetchNextNGateways(fetchCtx, 2, 3); err != nil {
 				n.log.Warn("registry fetch error", "err", err)
 			}
+			time.Sleep(time.Second)
 		}
 	}()
 

--- a/optimism/op-node/node/node.go
+++ b/optimism/op-node/node/node.go
@@ -254,6 +254,18 @@ func (n *OpNode) initRegistry(ctx context.Context, cfg *Config) error {
 		return fmt.Errorf("failed to fetch initial gateways: %w", err)
 	}
 
+	// Start fetching future gateways
+	go func() {
+		for {
+			fetchCtx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+			defer cancel()
+
+			if err := n.registrySource.FetchNextNGateways(fetchCtx, 2, 3); err != nil {
+				n.log.Warn("registry fetch error", "err", err)
+			}
+		}
+	}()
+
 	return nil
 }
 
@@ -764,16 +776,6 @@ func (n *OpNode) OnSealFrag(ctx context.Context, from peer.ID, seal *eth.SignedS
 	n.tracer.OnSealFrag(ctx, from, seal)
 	n.log.Info("Received new seal", "seal", seal)
 	n.preconfChannels.SendSeal(seal)
-
-	// Start fetching future gateways
-	go func() {
-		fetchCtx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-		defer cancel()
-
-		if err := n.registrySource.FetchNextNGateways(fetchCtx, 2, 3); err != nil {
-			n.log.Warn("registry fetch error", "err", err)
-		}
-	}()
 
 	return nil
 }

--- a/optimism/op-node/rollup/engine/engine_controller.go
+++ b/optimism/op-node/rollup/engine/engine_controller.go
@@ -141,7 +141,8 @@ func (e *EngineController) BackupUnsafeL2Head() eth.L2BlockRef {
 }
 
 func (e *EngineController) IsEngineSyncing() bool {
-	return e.syncStatus == syncStatusWillStartEL || e.syncStatus == syncStatusStartedEL || e.syncStatus == syncStatusFinishedELButNotFinalized
+	// return e.syncStatus == syncStatusWillStartEL || e.syncStatus == syncStatusStartedEL || e.syncStatus == syncStatusFinishedELButNotFinalized
+	return true
 }
 
 // Setters


### PR DESCRIPTION
Without always returning `true` on `IsEngineSyncing` in `op-node`, it will stop driving `op-geth` as soon as it sees a finalized block. Nothing, including frags, will go through anymore. 

Also fixed some txpool bugs and improved overseer when spamming txs:
 
![image](https://github.com/user-attachments/assets/711345b4-bcab-4c96-83dd-129fb2111ade)
