### PR TITLE
fix(based-txproxy): remove repeated `std::sync::atomic::Ordering::Relaxed`

### DIFF
--- a/based/bin/portal/src/server.rs
+++ b/based/bin/portal/src/server.rs
@@ -26,7 +26,6 @@ use tokio::sync::RwLock;
 use tower::ServiceBuilder;
 use tower_http::cors::{Any, CorsLayer};
 use tracing::{Instrument, Level, debug, error, info, trace};
-use std::sync::atomic::Ordering::Relaxed;
 
 use crate::{
     cli::PortalArgs,


### PR DESCRIPTION
Noticed that based-txproxy was not building on my machine, due to a repeated `use` statement in `based/bin/txproxy/src/server.rs`. Removing the duplicated line.
