### PR TITLE
feat(metrics): add bop-metrics crate skeleton

### DIFF
--- a/based/Cargo.lock
+++ b/based/Cargo.lock
@@ -1497,6 +1497,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c953fe1ba023e6b7730c0d4b031d06f267f23a46167dcbd40316644b10a17ba"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
+dependencies = [
+ "bindgen 0.69.5",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "backon"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1544,6 +1567,16 @@ name = "base64ct"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+
+[[package]]
+name = "based-metrics-exporter"
+version = "0.1.0"
+dependencies = [
+ "bop-common",
+ "bop-metrics",
+ "clap",
+ "tokio",
+]
 
 [[package]]
 name = "based-portal"
@@ -1610,6 +1643,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.9.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.10.5",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.101",
+ "which",
 ]
 
 [[package]]
@@ -1887,6 +1943,17 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.19",
+]
+
+[[package]]
+name = "bop-metrics"
+version = "0.1.0"
+dependencies = [
+ "bop-common",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2268,6 +2335,15 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -3356,6 +3432,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3830,6 +3912,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4733,6 +4824,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4791,7 +4888,7 @@ version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78a09b56be5adbcad5aa1197371688dc6bb249a26da3bca2011ee2fb987ebfb"
 dependencies = [
- "bindgen",
+ "bindgen 0.70.1",
  "errno",
  "libc",
 ]
@@ -5047,11 +5144,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
 dependencies = [
  "base64",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
  "indexmap 2.10.0",
+ "ipnet",
  "metrics",
  "metrics-util",
  "quanta",
  "thiserror 1.0.69",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -6070,6 +6174,16 @@ checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
  "yansi",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7587,7 +7701,7 @@ dependencies = [
 name = "reth-mdbx-sys"
 version = "1.3.11"
 dependencies = [
- "bindgen",
+ "bindgen 0.70.1",
  "cc",
 ]
 
@@ -9597,6 +9711,7 @@ version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -9670,6 +9785,7 @@ version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -11400,6 +11516,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]

--- a/based/Cargo.toml
+++ b/based/Cargo.toml
@@ -43,6 +43,7 @@ auto_impl = "1.3.0"
 axum = { version = "0.8.1", features = ["macros"] }
 bitflags = "2.6.0"
 bop-common = { path = "crates/common" }
+bop-metrics = { path = "crates/metrics" }
 bop-db = { path = "crates/db" }
 bop-pool = { path = "crates/pool" }
 bop-rpc = { path = "crates/rpc" }

--- a/based/bin/metrics_exporter/Cargo.toml
+++ b/based/bin/metrics_exporter/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+edition.workspace = true
+name = "based-metrics-exporter"
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+bop-common.workspace = true
+bop-metrics.workspace = true
+tokio.workspace = true
+clap.workspace = true

--- a/based/bin/metrics_exporter/src/main.rs
+++ b/based/bin/metrics_exporter/src/main.rs
@@ -1,0 +1,19 @@
+use bop_metrics::{consumer::MetricsConsumer, install_prometheus_exporter};
+use clap::Parser;
+
+/// Exposes metrics for Prometheus to scrape.
+#[derive(Debug, Parser)]
+struct Args {
+    /// The port to expose the metrics on. Default is 9464.
+    #[clap(short, long, default_value = "9464")]
+    port: u16,
+}
+
+#[tokio::main]
+async fn main() {
+    let args = Args::parse();
+
+    install_prometheus_exporter(args.port);
+
+    MetricsConsumer::default().run().await;
+}

--- a/based/crates/metrics/Cargo.toml
+++ b/based/crates/metrics/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+edition.workspace = true
+name = "bop-metrics"
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+bop-common.workspace = true
+tokio.workspace = true
+metrics-exporter-prometheus = "0.16.2"
+tracing.workspace = true
+metrics = "0.24.1"

--- a/based/crates/metrics/src/consumer.rs
+++ b/based/crates/metrics/src/consumer.rs
@@ -1,0 +1,44 @@
+use std::time::Duration;
+
+use bop_common::{
+    communication::Consumer,
+    telemetry::{Telemetry, TelemetryUpdate, Tx, telemetry_queue},
+};
+
+use crate::metrics::Metrics;
+
+/// Consumes telemetry updates from shared memory queues, and converts them into metrics.
+pub struct MetricsConsumer {
+    telemetry: Consumer<TelemetryUpdate>,
+}
+
+impl MetricsConsumer {
+    /// Runs the metrics consumer, consuming telemetry updates from shared queues,
+    /// and converting them into metrics.
+    pub async fn run(&mut self) {
+        loop {
+            while let Some(update) = self.telemetry.try_consume() {
+                self.process_update(update);
+            }
+
+            tokio::time::sleep(Duration::from_millis(50)).await
+        }
+    }
+
+    /// Processes a telemetry update, converting it into metrics.
+    fn process_update(&mut self, update: TelemetryUpdate) {
+        match update.update {
+            Telemetry::Tx(tx) => match tx {
+                Tx::Included(_) => Metrics::increase_gateway_tx_included_total(),
+                _ => todo!(),
+            },
+            _ => todo!(),
+        }
+    }
+}
+
+impl Default for MetricsConsumer {
+    fn default() -> Self {
+        Self { telemetry: telemetry_queue().into() }
+    }
+}

--- a/based/crates/metrics/src/lib.rs
+++ b/based/crates/metrics/src/lib.rs
@@ -1,0 +1,13 @@
+use metrics_exporter_prometheus::PrometheusBuilder;
+
+pub mod consumer;
+pub mod metrics;
+
+/// Installs the prometheus exporter on the given port.
+pub fn install_prometheus_exporter(port: u16) {
+    PrometheusBuilder::new()
+        .with_http_listener(([0, 0, 0, 0], port))
+        .add_global_label("instance", "based-optimism")
+        .install()
+        .expect("Failed to install prometheus exporter");
+}

--- a/based/crates/metrics/src/metrics.rs
+++ b/based/crates/metrics/src/metrics.rs
@@ -1,0 +1,9 @@
+/// Contains all metrics for the based monitoring stack.
+#[derive(Default)]
+pub struct Metrics;
+
+impl Metrics {
+    pub fn increase_gateway_tx_included_total() {
+        metrics::counter!("bop_gateway_tx_included_total").increment(1);
+    }
+}


### PR DESCRIPTION
This PR adds two crates to the `based` workspace:

* `crates/metrics`, responsible for defining metric names and consuming updates from shared queues
* `bin/metrics-exporter`, a binary responsible for running the Prometheus exporter server and running the metrics consumer loop from `bop_metrics` to collect data.

The idea is to leverage the existing telemetry queue (and eventually extend it where necessary) so that either this small binary or the `overseer` are valid consumers that can access its contents.