### PR TITLE
feat(metrics): setup basic monitoring infra for local dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ build-gateway: ## 🏗️ Build based gateway
 	docker build -t local_based_gateway -f ./based/gateway.Dockerfile --build-context reth=./reth ./based
 
 build-txproxy: ## 🏗️ Build based txproxy
-	docker build -t local_based_txproxy -f ./based/txproxy.Dockerfile --build-context reth=./reth ./based
+	docker build -t local_based_txproxy -f ./based/txproxy.Dockerfile --build-context reth=./reth ./based --load
 
 build-metrics-exporter: ## 🏗️ Build metrics exporter
 	docker build -t local_based_metrics_exporter -f ./based/metrics-exporter.Dockerfile --build-context reth=./reth ./based --load
@@ -205,15 +205,7 @@ start-based-gateway: create-network
 
 	@docker compose $(START_GATEWAY_COMPOSE_FILES) up -d
 	@docker compose $(START_MONITORING_COMPOSE_FILES) up -d
-	$(MAKE) start-metrics-exporter
 	$(MAKE) start-overseer
-
-start-metrics-exporter:
-	# TODO: use a ghcr.io image instead of a local one here
-	docker run -p 9000:9000 --name based-metrics-exporter --env RUST_LOG=bop_metrics_exporter=trace -d local_based_metrics_exporter --port 9000
-
-stop-metrics-exporter:
-	docker stop based-metrics-exporter && docker rm based-metrics-exporter
 
 start-overseer: 
 	docker exec -it based-gateway overseer --portal-url $(PORTAL) --rich-wallet-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
@@ -373,6 +365,7 @@ start-main-node: create-network
 	@echo
 
 	@docker compose $(START_MAIN_NODE_COMPOSE_FILES) up -d
+	@docker compose $(START_MONITORING_COMPOSE_FILES) up -d
 	$(MAKE) logs-main-node
 
 start-portal: build-portal
@@ -397,10 +390,6 @@ stop-based-gateway:
 	cd .local_gateway_and_follower && docker compose down
 	# also stop monitoring services, if they are running
 	$(MAKE) stop-monitoring
-	$(MAKE) stop-metrics-exporter
-
-stop-monitoring:
-	docker compose $(START_MONITORING_COMPOSE_FILES) down
 
 stop-main-node:
 	@if [ ! -d .local_main_node/config ]; then \
@@ -408,6 +397,11 @@ stop-main-node:
 		exit 1; \
 	fi
 	docker compose -f .local_main_node/compose.yml down
+	# also stop monitoring services, if they are running
+	$(MAKE) stop-monitoring
+
+stop-monitoring:
+	docker compose $(START_MONITORING_COMPOSE_FILES) down
 
 stop-portal:
 	@if [ ! -d .local_main_node/config ]; then \

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ IMAGE_OP_DEPLOYER:=ghcr.io/gattaca-com/based-optimism/based-op-deployer:latest
 
 START_GATEWAY_COMPOSE_FILES := -f .local_gateway_and_follower/compose.yml
 START_MAIN_NODE_COMPOSE_FILES := -f .local_main_node/compose.yml
+START_MONITORING_COMPOSE_FILES := -f monitoring/compose.yml
 
 # Overridable Variables
 L1_CHAIN_ID?=11155111
@@ -72,6 +73,9 @@ build-gateway: ## 🏗️ Build based gateway
 
 build-txproxy: ## 🏗️ Build based txproxy
 	docker build -t local_based_txproxy -f ./based/txproxy.Dockerfile --build-context reth=./reth ./based
+
+build-metrics-exporter: ## 🏗️ Build metrics exporter
+	docker build -t local_based_metrics_exporter -f ./based/metrics-exporter.Dockerfile --build-context reth=./reth ./based
 
 build-based-op-geth: ## 🏗️ Build OP geth from op-eth directory
 	docker build -t local_based_op_geth ../based-op-geth
@@ -200,7 +204,13 @@ start-based-gateway: create-network
       echo; echo
 
 	@docker compose $(START_GATEWAY_COMPOSE_FILES) up -d
+	@docker compose $(START_MONITORING_COMPOSE_FILES) up -d
+	$(MAKE) start-metrics-exporter
 	$(MAKE) start-overseer
+
+start-metrics-exporter:
+	# TODO: use a ghcr.io image instead of a local one here
+	docker run -p 9000:9000 -d local_based_metrics_exporter --port 9000
 
 start-overseer: 
 	docker exec -it based-gateway overseer --portal-url $(PORTAL) --rich-wallet-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
@@ -379,9 +389,14 @@ start-registry: build-registry
 	$(MAKE) fix-compose
 	docker compose -f .local_main_node/compose.yml up -d based-registry 
 	$(MAKE) logs-registry
-	
+
 stop-based-gateway:
 	cd .local_gateway_and_follower && docker compose down
+	# also stop monitoring services, if they are running
+	$(MAKE) stop-monitoring
+
+stop-monitoring:
+	docker compose $(START_MONITORING_COMPOSE_FILES) down
 
 stop-main-node:
 	@if [ ! -d .local_main_node/config ]; then \

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ build-txproxy: ## 🏗️ Build based txproxy
 	docker build -t local_based_txproxy -f ./based/txproxy.Dockerfile --build-context reth=./reth ./based
 
 build-metrics-exporter: ## 🏗️ Build metrics exporter
-	docker build -t local_based_metrics_exporter -f ./based/metrics-exporter.Dockerfile --build-context reth=./reth ./based
+	docker build -t local_based_metrics_exporter -f ./based/metrics-exporter.Dockerfile --build-context reth=./reth ./based --load
 
 build-based-op-geth: ## 🏗️ Build OP geth from op-eth directory
 	docker build -t local_based_op_geth ../based-op-geth
@@ -210,7 +210,10 @@ start-based-gateway: create-network
 
 start-metrics-exporter:
 	# TODO: use a ghcr.io image instead of a local one here
-	docker run -p 9000:9000 -d local_based_metrics_exporter --port 9000
+	docker run -p 9000:9000 --name based-metrics-exporter --env RUST_LOG=bop_metrics_exporter=trace -d local_based_metrics_exporter --port 9000
+
+stop-metrics-exporter:
+	docker stop based-metrics-exporter && docker rm based-metrics-exporter
 
 start-overseer: 
 	docker exec -it based-gateway overseer --portal-url $(PORTAL) --rich-wallet-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
@@ -394,6 +397,7 @@ stop-based-gateway:
 	cd .local_gateway_and_follower && docker compose down
 	# also stop monitoring services, if they are running
 	$(MAKE) stop-monitoring
+	$(MAKE) stop-metrics-exporter
 
 stop-monitoring:
 	docker compose $(START_MONITORING_COMPOSE_FILES) down

--- a/based/Cargo.lock
+++ b/based/Cargo.lock
@@ -1954,6 +1954,8 @@ dependencies = [
  "bop-metrics",
  "clap",
  "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.19",
 ]
 
 [[package]]

--- a/based/Cargo.lock
+++ b/based/Cargo.lock
@@ -1569,16 +1569,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
-name = "based-metrics-exporter"
-version = "0.1.0"
-dependencies = [
- "bop-common",
- "bop-metrics",
- "clap",
- "tokio",
-]
-
-[[package]]
 name = "based-portal"
 version = "0.1.0"
 dependencies = [
@@ -1954,6 +1944,16 @@ dependencies = [
  "metrics-exporter-prometheus",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "bop-metrics-exporter"
+version = "0.1.0"
+dependencies = [
+ "bop-common",
+ "bop-metrics",
+ "clap",
+ "tokio",
 ]
 
 [[package]]

--- a/based/Cargo.toml
+++ b/based/Cargo.toml
@@ -130,7 +130,7 @@ tower = "0.4"
 tower-http = { version = "0.6.4", features = ["cors"] }
 tracing = "0.1.41"
 tracing-appender = "0.2.3"
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.19", features = ["env-filter", "fmt"] }
 tree_hash = "0.10"
 tree_hash_derive = "0.10"
 uuid = { version = "1.12.1", features = ["serde", "v4"] }

--- a/based/bin/metrics_exporter/Cargo.toml
+++ b/based/bin/metrics_exporter/Cargo.toml
@@ -12,4 +12,4 @@ tokio.workspace = true
 clap.workspace = true
 
 tracing.workspace = true
-tracing-subscriber = { version = "0.3.19", features = ["env-filter", "fmt"] }
+tracing-subscriber.workspace = true

--- a/based/bin/metrics_exporter/Cargo.toml
+++ b/based/bin/metrics_exporter/Cargo.toml
@@ -7,5 +7,9 @@ version.workspace = true
 [dependencies]
 bop-common.workspace = true
 bop-metrics.workspace = true
+
 tokio.workspace = true
 clap.workspace = true
+
+tracing.workspace = true
+tracing-subscriber = { version = "0.3.19", features = ["env-filter", "fmt"] }

--- a/based/bin/metrics_exporter/Cargo.toml
+++ b/based/bin/metrics_exporter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 edition.workspace = true
-name = "based-metrics-exporter"
+name = "bop-metrics-exporter"
 rust-version.workspace = true
 version.workspace = true
 

--- a/based/bin/metrics_exporter/src/main.rs
+++ b/based/bin/metrics_exporter/src/main.rs
@@ -1,5 +1,7 @@
 use bop_metrics::{consumer::MetricsConsumer, install_prometheus_exporter};
 use clap::Parser;
+use tracing::{info, level_filters::LevelFilter};
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
 /// Exposes metrics for Prometheus to scrape.
 #[derive(Debug, Parser)]
@@ -11,9 +13,17 @@ struct Args {
 
 #[tokio::main]
 async fn main() {
+    // Parse CLI arguments
     let args = Args::parse();
 
-    install_prometheus_exporter(args.port);
+    // Init tracing
+    let env = EnvFilter::builder().with_default_directive(LevelFilter::INFO.into()).from_env_lossy();
+    tracing_subscriber::registry().with(env).with(tracing_subscriber::fmt::layer()).init();
 
+    // Init Prometheus server
+    install_prometheus_exporter(args.port);
+    info!("Prometheus server started on port {}", args.port);
+
+    // Start the metrics consumer loop
     MetricsConsumer::default().run().await;
 }

--- a/based/crates/metrics/src/consumer.rs
+++ b/based/crates/metrics/src/consumer.rs
@@ -4,6 +4,7 @@ use bop_common::{
     communication::Consumer,
     telemetry::{Telemetry, TelemetryUpdate, Tx, telemetry_queue},
 };
+use tracing::trace;
 
 use crate::metrics::Metrics;
 
@@ -18,6 +19,7 @@ impl MetricsConsumer {
     pub async fn run(&mut self) {
         loop {
             while let Some(update) = self.telemetry.try_consume() {
+                trace!(?update, "Received telemetry update");
                 self.process_update(update);
             }
 
@@ -29,6 +31,7 @@ impl MetricsConsumer {
     fn process_update(&mut self, update: TelemetryUpdate) {
         match update.update {
             Telemetry::Tx(tx) => match tx {
+                Tx::AddedToPool => Metrics::increase_gateway_tx_added_to_pool_total(),
                 Tx::Included(_) => Metrics::increase_gateway_tx_included_total(),
                 _ => todo!(),
             },

--- a/based/crates/metrics/src/consumer.rs
+++ b/based/crates/metrics/src/consumer.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use bop_common::{
     communication::Consumer,
-    telemetry::{Telemetry, TelemetryUpdate, Tx, telemetry_queue},
+    telemetry::{Telemetry, TelemetryUpdate, Tx, system::SystemNotification, telemetry_queue},
 };
 use tracing::trace;
 
@@ -33,9 +33,23 @@ impl MetricsConsumer {
             Telemetry::Tx(tx) => match tx {
                 Tx::AddedToPool => Metrics::increase_gateway_tx_added_to_pool_total(),
                 Tx::Included(_) => Metrics::increase_gateway_tx_included_total(),
-                _ => todo!(),
+                _ => {
+                    // TODO
+                }
             },
-            _ => todo!(),
+            Telemetry::System(system) => match system {
+                SystemNotification::StateChanged(state) => Metrics::set_sequencer_state(state),
+                SystemNotification::BlockSync(block_number, _gas_used) => {
+                    Metrics::set_block_sync_block_number(block_number)
+                }
+                SystemNotification::Sorting(block_number) => Metrics::set_sorting_block_number(block_number),
+                _ => {
+                    // TODO
+                }
+            },
+            _ => {
+                // TODO
+            }
         }
     }
 }

--- a/based/crates/metrics/src/metrics.rs
+++ b/based/crates/metrics/src/metrics.rs
@@ -1,13 +1,28 @@
+use bop_common::telemetry::system::SequencerState;
+use metrics::{counter, gauge};
+
 /// Contains all metrics for the based monitoring stack.
 #[derive(Default)]
 pub struct Metrics;
 
 impl Metrics {
     pub fn increase_gateway_tx_added_to_pool_total() {
-        metrics::counter!("bop_gateway_tx_added_to_pool_total").increment(1);
+        counter!("bop_gateway_tx_added_to_pool_total").increment(1);
     }
 
     pub fn increase_gateway_tx_included_total() {
-        metrics::counter!("bop_gateway_tx_included_total").increment(1);
+        counter!("bop_gateway_tx_included_total").increment(1);
+    }
+
+    pub fn set_sequencer_state(state: SequencerState) {
+        gauge!("bop_sequencer_state").set(state as u8);
+    }
+
+    pub fn set_block_sync_block_number(block_number: u64) {
+        gauge!("bop_block_sync_block_number").set(block_number as f64);
+    }
+
+    pub fn set_sorting_block_number(block_number: u64) {
+        gauge!("bop_sorting_block_number").set(block_number as f64);
     }
 }

--- a/based/crates/metrics/src/metrics.rs
+++ b/based/crates/metrics/src/metrics.rs
@@ -3,6 +3,10 @@
 pub struct Metrics;
 
 impl Metrics {
+    pub fn increase_gateway_tx_added_to_pool_total() {
+        metrics::counter!("bop_gateway_tx_added_to_pool_total").increment(1);
+    }
+
     pub fn increase_gateway_tx_included_total() {
         metrics::counter!("bop_gateway_tx_included_total").increment(1);
     }

--- a/based/metrics-exporter.Dockerfile
+++ b/based/metrics-exporter.Dockerfile
@@ -1,0 +1,28 @@
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y clang
+
+FROM chef AS planner
+COPY . .
+RUN --mount=from=reth,target=/reth cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder 
+COPY --from=planner /app/recipe.json recipe.json
+
+RUN --mount=from=reth,target=/reth cargo chef cook --release --recipe-path recipe.json
+
+COPY . .
+RUN --mount=from=reth,target=/reth cargo build --release --bin bop-metrics-exporter
+
+
+FROM debian:stable-slim AS runtime
+WORKDIR /app
+
+RUN apt-get update
+RUN apt-get install -y openssl ca-certificates libssl3 libssl-dev
+
+COPY --from=builder /app/target/release/bop-metrics-exporter /usr/local/bin
+ENTRYPOINT ["/usr/local/bin/bop-metrics-exporter"]

--- a/monitoring/compose.yml
+++ b/monitoring/compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - 9090:9090
     volumes:
-      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus-data:/prometheus
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
@@ -25,9 +25,9 @@ services:
       - 3000:3000
     volumes:
       - grafana-data:/var/lib/grafana
-      - ./monitoring/grafana/datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml:ro
-      - ./monitoring/grafana/dashboards:/etc/grafana/provisioning/dashboards
-      - ./monitoring/grafana/dashboards:/etc/grafana/dashboards
+      - ./grafana/datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml:ro
+      - ./grafana/dashboards:/etc/grafana/provisioning/dashboards
+      - ./grafana/dashboards:/etc/grafana/dashboards
     environment:
       - GF_SECURITY_ADMIN_USER=based-op
       - GF_SECURITY_ADMIN_PASSWORD=grafana

--- a/monitoring/compose.yml
+++ b/monitoring/compose.yml
@@ -1,4 +1,18 @@
 services:
+  based-metrics-exporter:
+    image: local_based_metrics_exporter # TODO: use a ghcr.io image
+    container_name: based-metrics-exporter
+    restart: unless-stopped
+    environment:
+      - RUST_LOG=bop_metrics_exporter=trace
+    volumes:
+      - /tmp:/tmp
+      - /dev/shm:/dev/shm
+    command:
+      - "--port=9000"
+    networks:
+      - monitoring
+
   prometheus:
     image: prom/prometheus:latest
     container_name: prometheus

--- a/monitoring/compose.yml
+++ b/monitoring/compose.yml
@@ -1,0 +1,45 @@
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    restart: unless-stopped
+    ports:
+      - 9090:9090
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.console.libraries=/etc/prometheus/console_libraries"
+      - "--web.console.templates=/etc/prometheus/consoles"
+      - "--web.enable-lifecycle"
+    networks:
+      - monitoring
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    restart: unless-stopped
+    ports:
+      - 3000:3000
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./monitoring/grafana/datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml:ro
+      - ./monitoring/grafana/dashboards:/etc/grafana/provisioning/dashboards
+      - ./monitoring/grafana/dashboards:/etc/grafana/dashboards
+    environment:
+      - GF_SECURITY_ADMIN_USER=based-op
+      - GF_SECURITY_ADMIN_PASSWORD=grafana
+    networks:
+      - monitoring
+    depends_on:
+      - prometheus
+
+volumes:
+  prometheus-data:
+  grafana-data:
+
+networks:
+  monitoring:
+    driver: bridge

--- a/monitoring/grafana/datasource.yml
+++ b/monitoring/grafana/datasource.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    url: http://prometheus:9090
+    isDefault: true
+    access: proxy
+    editable: false

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 30s
+
+scrape_configs:
+  - job_name: "bop-metrics-exporter"
+    static_configs:
+      - targets: ["localhost:9000"]

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -5,4 +5,4 @@ global:
 scrape_configs:
   - job_name: "bop-metrics-exporter"
     static_configs:
-      - targets: ["localhost:9000"]
+      - targets: ["172.17.0.1:9000"]

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -5,4 +5,4 @@ global:
 scrape_configs:
   - job_name: "bop-metrics-exporter"
     static_configs:
-      - targets: ["172.17.0.1:9000"]
+      - targets: ["based-metrics-exporter:9000"]


### PR DESCRIPTION
This PR adds a basic grafana+prom docker compose to the local dev stack, along with the ability to build and start the new `bop-metrics-exporter` crate added in #203.

The monitoring setup has been tested locally with `make start-based-gateway`.

More complete metrics will be added in separate PRs.