### PR TITLE
fix: add missing volume in main_node compose for based-txproxy

### DIFF
--- a/main_node/compose.yml
+++ b/main_node/compose.yml
@@ -174,6 +174,8 @@ services:
     command:
       - --tx_receivers.path=/config/tx_receivers.json
       - --port=${TXPROXY_PORT}
+    volumes: 
+      - ./config:/config
     restart: unless-stopped
 
 # ################################################################################


### PR DESCRIPTION
Otherwise when starting with `make start-main-node`, the `based-txproxy` is in a crash loop