### PR TITLE
fix(portal): proxy portal_ namespace to internal proxy

### DIFF
--- a/based/bin/portal/src/middleware.rs
+++ b/based/bin/portal/src/middleware.rs
@@ -32,6 +32,10 @@ where
 
         async move {
             match req.method_name().split_once('_') {
+                Some(("portal", _)) => {
+                    debug!(method = %method, "Received request in PortalApiProxy");
+                    inner.call(req).await
+                }
                 Some(("engine", _)) => {
                     debug!(method = %method, "Received request in EngineApiProxy");
                     inner.call(req).await


### PR DESCRIPTION
### issue

`portal_` namespace requests were currently proxied to the fallback client, thus returning `MethodNotFound`.
This was introduced in the changes here: https://github.com/gattaca-com/based-op/pull/198/files#diff-c25726d092f17e678a91a3414a4ec3fd79e59cbdbbbf057978b1d49e3ed9ed5bL54-L56

Here are logs of the old image running with debug logs:

```
2025-08-21T12:54:55.254261Z DEBUG Forwarding request to fallback client method=portal_opNodeBootnodeEnr
2025-08-21T12:54:55.256554Z ERROR Error calling client error=ErrorObject { code: MethodNotFound, message: "the method portal_opNodeBootnodeEnr does not exist/is not available", data: None }
```

### solution

The RPC middleware now handles this namespace separately.
Testing main-node with a local version of the image yielded a successful result for `portal_opGethBootnodeEnode`:

```
❯ cast rpc --rpc-url http://localhost:8080 portal_opGethBootnodeEnode
"enode://5ea845cd25c593d37d864b870642982853c81cfbdb692d39546b18c992ac6eda8cc0d3a181eb70100ebf0a3437d15e60f27fa7e9583de737d27bd190e58b313d@151.0.207.195:30303"
```

Proxying requests:

```
❯ docker logs based-portal | grep "portal_"
2025-08-21T13:46:48.332192Z DEBUG Received request in PortalApiProxy method=portal_opNodeGossipStatic
2025-08-21T13:46:48.681107Z DEBUG Received request in PortalApiProxy method=portal_opNodeBootnodeEnr
2025-08-21T13:46:48.966476Z DEBUG Received request in PortalApiProxy method=portal_opGethBootnodeEnode
```