### PR TITLE
fix(portal): also proxy op_node requests for overseer to startup

### DIFF
--- a/based/bin/portal/src/middleware.rs
+++ b/based/bin/portal/src/middleware.rs
@@ -15,6 +15,7 @@ pub struct EngineApiProxy<S> {
     pub inner: S,
     pub geth_client: AuthRpcClient,
     pub registry_client: RpcClient,
+    pub op_node_client: RpcClient,
 }
 
 impl<'a, S> RpcServiceT<'a> for EngineApiProxy<S>
@@ -29,6 +30,7 @@ where
         let method = req.method_name().to_string();
         let fallback_client = self.geth_client.clone();
         let registry_client = self.registry_client.clone();
+        let op_node_client = self.op_node_client.clone();
 
         async move {
             match req.method_name().split_once('_') {
@@ -43,6 +45,10 @@ where
                 Some(("registry", _)) => {
                     debug!(method = %method, "Received request in RegistryApiProxy");
                     external_call(registry_client.clone(), &req).await
+                }
+                Some(("optimism", _)) | Some(("opp2p", _)) => {
+                    debug!(method = %method, "Received request for OP node");
+                    external_call(op_node_client.clone(), &req).await
                 }
                 _ => {
                     debug!(method = %method, "Forwarding request to fallback client. request: {:?}", req);

--- a/based/bin/portal/src/server.rs
+++ b/based/bin/portal/src/server.rs
@@ -73,11 +73,13 @@ impl PortalServer {
     pub async fn run(self, addr: SocketAddr) -> eyre::Result<()> {
         let geth_engine_client = self.geth_engine_client.clone();
         let registry_client = self.gateway_manager.registry_client.clone();
+        let op_node_client = self.op_node_client.clone();
 
         let rpc_middleware = RpcServiceBuilder::new().layer_fn(move |s| EngineApiProxy {
             inner: s,
             geth_client: geth_engine_client.clone(),
             registry_client: registry_client.clone(),
+            op_node_client: op_node_client.clone(),
         });
 
         // temp: remove when factoring out the portal


### PR DESCRIPTION
similar to #210 but to make `overseer` start up.

https://github.com/gattaca-com/based-op/blob/0e88598c77d5708ca276437cea207a8749f4cd37/based/bin/overseer/src/main.rs#L137-L138