### PR TITLE
Basic spamoor integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ L2_CHAIN_ID?=$(shell \
     echo $$((RAW % 50000 + 1)); \
 )
 L2_CHAIN_ID_HEX:=$(shell printf "0x%064x" $(L2_CHAIN_ID))
-PORTAL?=http://18.185.199.51:8080
+PORTAL?=http://0.0.0.0:8080
+TX_PROXY?=http://0.0.0.0:8090
 L1_RPC_URL?=http://34.194.193.217:8545
 L1_BEACON_RPC_URL?=http://34.194.193.217:5052
 PUBLIC_IP?=$(shell curl ifconfig.me)
@@ -217,7 +218,7 @@ start-spamoor:
 	ghcr.io/chainbound/spamoor-op-geth run \
 		/etc/spamoor-config.yml \
 		--privkey $(DUMMY_RICH_WALLET_PRIVATE_KEY) \
-		--rpchost http://0.0.0.0:$(LOCAL_GETH_PORT)
+		--rpchost http://0.0.0.0:$(BASED_OP_GETH_PORT)
 
 # ────────────────────────────────────────────────────────────────────────────────
 # Only perform these parse-time checks if the user asked for deploy-chain
@@ -470,10 +471,10 @@ FOLLOWER_NODE_HOST?=http://localhost
 BLOCK_NUMBER?=$(shell echo $$(( $$(cast block-number --rpc-url http://localhost:$(BOP_EL_PORT)) + 1 )))
 DUMMY_RICH_WALLET_PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 DUMMY_TX=$(shell cast mktx --rpc-url  $(FOLLOWER_NODE_HOST):$(BOP_EL_PORT) --private-key $(DUMMY_RICH_WALLET_PRIVATE_KEY) --value 1 0x7DDcC7c49D562997A68C98ae7Bb62eD1E8E4488a | xxd -r -p | base64)
-LOCAL_GETH_PORT?=8645
+BASED_OP_GETH_PORT?=8645
 
 test-tx:
-	cast send --rpc-url  http://0.0.0.0:$(LOCAL_GETH_PORT) --private-key $(DUMMY_RICH_WALLET_PRIVATE_KEY) --value 1 0x7DDcC7c49D562997A68C98ae7Bb62eD1E8E4488a
+	cast send --rpc-url  http://0.0.0.0:$(BASED_OP_GETH_PORT) --private-key $(DUMMY_RICH_WALLET_PRIVATE_KEY) --value 1 0x7DDcC7c49D562997A68C98ae7Bb62eD1E8E4488a
 
 test-frag:
 	curl --request POST   --url $(FOLLOWER_NODE_HOST):$(BOP_NODE_PORT) --header 'Content-Type: application/json' \

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ L2_CHAIN_ID?=$(shell \
 )
 L2_CHAIN_ID_HEX:=$(shell printf "0x%064x" $(L2_CHAIN_ID))
 PORTAL?=http://0.0.0.0:8080
-TX_PROXY?=http://0.0.0.0:8090
+TXPROXY?=http://0.0.0.0:8090
 L1_RPC_URL?=http://34.194.193.217:8545
 L1_BEACON_RPC_URL?=http://34.194.193.217:5052
 PUBLIC_IP?=$(shell curl ifconfig.me)

--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,15 @@ start-based-gateway: create-network
 start-overseer: 
 	docker exec -it based-gateway overseer --portal-url $(PORTAL) --rich-wallet-key $(DUMMY_RICH_WALLET_PRIVATE_KEY)
 
+start-spamoor:
+	docker run \
+		--network host \
+		--volume ./spamoor-config.yml:/etc/spamoor-config.yml \
+	ethpandaops/spamoor run \
+		/etc/spamoor-config.yml \
+		--privkey $(DUMMY_RICH_WALLET_PRIVATE_KEY) \
+		--rpchost http://0.0.0.0:$(LOCAL_GETH_PORT)
+
 # ────────────────────────────────────────────────────────────────────────────────
 # Only perform these parse-time checks if the user asked for deploy-chain
 # or start-main-node on the command line.

--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ start-spamoor:
 	docker run \
 		--network host \
 		--volume ./spamoor-config.yml:/etc/spamoor-config.yml \
-	ethpandaops/spamoor run \
+	ghcr.io/chainbound/spamoor-op-geth run \
 		/etc/spamoor-config.yml \
 		--privkey $(DUMMY_RICH_WALLET_PRIVATE_KEY) \
 		--rpchost http://0.0.0.0:$(LOCAL_GETH_PORT)

--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,7 @@ start-based-gateway: create-network
 start-overseer: 
 	docker exec -it based-gateway overseer --portal-url $(PORTAL) --rich-wallet-key $(DUMMY_RICH_WALLET_PRIVATE_KEY)
 
+# start spamoor as a foreground process
 start-spamoor:
 	docker run \
 		--pull always \
@@ -219,7 +220,16 @@ start-spamoor:
 	ghcr.io/chainbound/spamoor-op-geth run \
 		/etc/spamoor-config.yml \
 		--privkey $(DUMMY_RICH_WALLET_PRIVATE_KEY) \
-		--rpchost http://0.0.0.0:$(BASED_OP_GETH_PORT)
+		--rpchost http://localhost:$(BASED_OP_GETH_PORT)
+
+# start spamoor daemon UI on port 8075
+start-spamoor-daemon:
+	docker run --rm --network host --entrypoint ./spamoor-daemon \
+		ghcr.io/chainbound/spamoor-op-geth \
+		--privkey $(DUMMY_RICH_WALLET_PRIVATE_KEY) \
+		--rpchost http://localhost:$(BASED_OP_GETH_PORT) \
+		--db /tmp/spamoor.db \
+		--port 8075 
 
 # ────────────────────────────────────────────────────────────────────────────────
 # Only perform these parse-time checks if the user asked for deploy-chain

--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,7 @@ start-overseer:
 
 start-spamoor:
 	docker run \
+		--pull always \
 		--network host \
 		--volume ./spamoor-config.yml:/etc/spamoor-config.yml \
 	ghcr.io/chainbound/spamoor-op-geth run \

--- a/follower_node/compose.yml
+++ b/follower_node/compose.yml
@@ -41,7 +41,7 @@ services:
           --discovery.port=$OP_GETH_GOSSIP_PORT \
           --port=$OP_GETH_GOSSIP_PORT \
           --bootnodes=$MAIN_OP_GETH_ENODE \
-          --rollup.sequencerhttp=$TX_PROXY
+          --rollup.sequencerhttp=$TXPROXY
 
     volumes:
       - ./data/geth:/data/geth

--- a/follower_node/compose.yml
+++ b/follower_node/compose.yml
@@ -41,7 +41,7 @@ services:
           --discovery.port=$OP_GETH_GOSSIP_PORT \
           --port=$OP_GETH_GOSSIP_PORT \
           --bootnodes=$MAIN_OP_GETH_ENODE \
-          --rollup.sequencerhttp=$TXPROXY
+          --rollup.sequencerhttp=$TX_PROXY
 
     volumes:
       - ./data/geth:/data/geth

--- a/main_node/tx_receivers_example.json
+++ b/main_node/tx_receivers_example.json
@@ -1,3 +1,4 @@
 [
-    "http://localhost:8545/"
+    "http://localhost:8545/",
+    "http://localhost:9998/"
 ]

--- a/spamoor-config.yml
+++ b/spamoor-config.yml
@@ -6,11 +6,9 @@
     refill_amount: 1000000000000000000 # 1 ETH in wei
     refill_balance: 500000000000000000 # 0.5 ETH in wei
     refill_interval: 600 # 10 minutes
-    throughput: 400 # Every 12 seconds
+    throughput: 400
     max_pending: 800
     max_wallets: 200
-    base_fee: 20 # gwei
-    tip_fee: 2 # gwei
     amount: 100 # 100 wei per transfer
     random_amount: true
     random_target: true
@@ -22,8 +20,23 @@
     seed: erctx-demo
     refill_amount: 2000000000000000000 # 2 ETH
     refill_balance: 1000000000000000000 # 1 ETH
-    throughput: 100 # Every 12 seconds
+    throughput: 100
     max_pending: 200
     max_wallets: 100
     amount: 50
     random_amount: true
+
+- scenario: uniswap-swaps
+  name: "Uniswap swaps"
+  description: "type-2 swap transactions with uniswap v2 pools"
+  config:
+    throughput: 1600
+    max_pending: 800
+    max_wallets: 50
+    rebroadcast: 120
+    pair_count: 1
+    min_swap_amount: "100000000000000000"
+    max_swap_amount: "1000000000000000000000"
+    buy_ratio: 50
+    slippage: 50
+    sell_threshold: "100000000000000000000000"

--- a/spamoor-config.yml
+++ b/spamoor-config.yml
@@ -1,0 +1,29 @@
+- scenario: eoatx
+  name: "High Volume ETH Transfers"
+  description: "Basic ETH transfers with 400 tx/slot throughput"
+  config:
+    seed: eoatx-demo
+    refill_amount: 1000000000000000000 # 1 ETH in wei
+    refill_balance: 500000000000000000 # 0.5 ETH in wei
+    refill_interval: 600 # 10 minutes
+    throughput: 400
+    max_pending: 800
+    max_wallets: 200
+    base_fee: 20 # gwei
+    tip_fee: 2 # gwei
+    amount: 100 # 100 wei per transfer
+    random_amount: true
+    random_target: true
+
+- scenario: erctx
+  name: "ERC20 Token Spammer"
+  description: "Deploy and transfer ERC20 tokens"
+  config:
+    seed: erctx-demo
+    refill_amount: 2000000000000000000 # 2 ETH
+    refill_balance: 1000000000000000000 # 1 ETH
+    throughput: 100
+    max_pending: 200
+    max_wallets: 100
+    amount: 50
+    random_amount: true

--- a/spamoor-config.yml
+++ b/spamoor-config.yml
@@ -6,7 +6,7 @@
     refill_amount: 1000000000000000000 # 1 ETH in wei
     refill_balance: 500000000000000000 # 0.5 ETH in wei
     refill_interval: 600 # 10 minutes
-    throughput: 400
+    throughput: 400 # Every 12 seconds
     max_pending: 800
     max_wallets: 200
     base_fee: 20 # gwei
@@ -22,7 +22,7 @@
     seed: erctx-demo
     refill_amount: 2000000000000000000 # 2 ETH
     refill_balance: 1000000000000000000 # 1 ETH
-    throughput: 100
+    throughput: 100 # Every 12 seconds
     max_pending: 200
     max_wallets: 100
     amount: 50

--- a/spamoor-config.yml
+++ b/spamoor-config.yml
@@ -30,6 +30,7 @@
   name: "Uniswap swaps"
   description: "type-2 swap transactions with uniswap v2 pools"
   config:
+    seed: uniswap-swaps-demo
     throughput: 1600
     max_pending: 800
     max_wallets: 50


### PR DESCRIPTION
This PR adds basic functionality for [ethpandaop's spamoor](https://github.com/ethpandaops/spamoor) for load testing.

In the Makefile, I've added a public image from Chainbound's GHCR based on a fork which supports Optimism (see [here](https://github.com/ethpandaops/spamoor/issues/117) for more details).

Other notable changes:
1. In the docker compose file of the follower node, based-op-geth is started with the `rollup.sequencerhttp` flag set to the based-txproxy instead of the portal. In this way, the spammer (or a user) can use based-op-geth for various `eth_` methods and then raw transactions can be forwarded by the proxy to the appropriate endpoints.
2. In the `tx_receivers_example.json` for the based-txproxy, it has been added the no-auth port 9998 of the gateway which supports `eth_sendRawTransactions`. 

### Deamon mode

`make start-spamoor-daemon` will start a UI on port 8075 with the full spamoor suite. It's especially useful to look at the performance, gas used, and pending transactions. 