### PR TITLE
feat(telemetry): add Promtail + Loki

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,9 +77,6 @@ build-txproxy: ## 🏗️ Build based txproxy
 build-metrics-exporter: ## 🏗️ Build metrics exporter
 	docker build -t local_based_metrics_exporter -f ./based/metrics-exporter.Dockerfile --build-context reth=./reth ./based --load
 
-build-metrics-exporter: ## 🏗️ Build metrics exporter
-	docker build -t local_based_metrics_exporter -f ./based/metrics-exporter.Dockerfile --build-context reth=./reth ./based --load
-
 build-based-op-geth: ## 🏗️ Build OP geth from op-eth directory
 	docker build -t local_based_op_geth ../based-op-geth
 

--- a/based/Cargo.lock
+++ b/based/Cargo.lock
@@ -11014,6 +11014,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "time",
  "tracing",
  "tracing-core",
  "tracing-log",

--- a/based/Cargo.toml
+++ b/based/Cargo.toml
@@ -132,7 +132,7 @@ tower = "0.4"
 tower-http = { version = "0.6.4", features = ["cors"] }
 tracing = "0.1.41"
 tracing-appender = "0.2.3"
-tracing-subscriber = { version = "0.3.19", features = ["env-filter", "fmt"] }
+tracing-subscriber = { version = "0.3.19", features = ["env-filter", "fmt", "time"] }
 tree_hash = "0.10"
 tree_hash_derive = "0.10"
 uuid = { version = "1.12.1", features = ["serde", "v4"] }

--- a/based/bin/gateway_registry/src/main.rs
+++ b/based/bin/gateway_registry/src/main.rs
@@ -59,6 +59,14 @@ pub struct RegistryArgs {
     #[arg(long = "log.prefix", default_value = "bop-portal.log")]
     pub log_prefix: String,
 
+    /// Path for log files
+    #[arg(long = "log.dir", default_value = "/tmp")]
+    pub log_dir: PathBuf,
+
+    /// Maximum number of log files
+    #[arg(long = "log.max_files", default_value_t = 100)]
+    pub log_max_files: usize,
+
     /// mock blocknumber
     #[arg(long = "use_mock_blocknumber", default_value_t = false)]
     pub use_mock_blocknumber: bool,
@@ -74,8 +82,8 @@ impl From<&RegistryArgs> for LoggingConfig {
                 .unwrap_or(LevelFilter::INFO),
             flags: if args.file_logging { LoggingFlags::all() } else { LoggingFlags::StdOut },
             prefix: args.file_logging.then(|| args.log_prefix.clone()),
-            max_files: 100,
-            path: PathBuf::from("/tmp"),
+            max_files: args.log_max_files,
+            path: args.log_dir.clone(),
             filters: None,
         }
     }

--- a/based/bin/gateway_registry/src/main.rs
+++ b/based/bin/gateway_registry/src/main.rs
@@ -56,7 +56,7 @@ pub struct RegistryArgs {
     pub file_logging: bool,
 
     /// Prefix of log files
-    #[arg(long = "log.prefix", default_value = "bop-portal.log")]
+    #[arg(long = "log.prefix", default_value = "bop-registry.log")]
     pub log_prefix: String,
 
     /// Path for log files

--- a/based/bin/portal/src/cli.rs
+++ b/based/bin/portal/src/cli.rs
@@ -61,6 +61,12 @@ pub struct PortalArgs {
     /// Prefix of log files
     #[arg(long = "log.prefix", default_value = "bop-portal.log")]
     pub log_prefix: String,
+    /// Path for log files
+    #[arg(long = "log.dir", default_value = "/tmp")]
+    pub log_dir: PathBuf,
+    /// Maximum number of log files
+    #[arg(long = "log.max_files", default_value_t = 100)]
+    pub log_max_files: usize,
 
     /// gateway inactivity timeout in milliseconds
     #[arg(long = "gateway.inactivity_timeout_ms", default_value_t = 3000)]
@@ -86,8 +92,8 @@ impl From<&PortalArgs> for LoggingConfig {
                 .unwrap_or(LevelFilter::INFO),
             flags: if args.file_logging { LoggingFlags::all() } else { LoggingFlags::StdOut },
             prefix: args.file_logging.then(|| args.log_prefix.clone()),
-            max_files: 100,
-            path: PathBuf::from("/tmp"),
+            max_files: args.log_max_files,
+            path: args.log_dir.clone(),
             filters: None,
         }
     }

--- a/based/bin/txproxy/src/cli.rs
+++ b/based/bin/txproxy/src/cli.rs
@@ -25,6 +25,12 @@ pub struct TxProxyArgs {
     /// Prefix of log files
     #[arg(long = "log.prefix", default_value = "bop-txproxy.log")]
     pub log_prefix: String,
+    /// Path for log files
+    #[arg(long = "log.dir", default_value = "/tmp")]
+    pub log_dir: PathBuf,
+    /// Maximum number of log files
+    #[arg(long = "log.max_files", default_value_t = 100)]
+    pub log_max_files: usize,
 }
 
 impl From<&TxProxyArgs> for LoggingConfig {
@@ -37,8 +43,8 @@ impl From<&TxProxyArgs> for LoggingConfig {
                 .unwrap_or(LevelFilter::INFO),
             flags: if args.file_logging { LoggingFlags::all() } else { LoggingFlags::StdOut },
             prefix: args.file_logging.then(|| args.log_prefix.clone()),
-            max_files: 100,
-            path: PathBuf::from("/tmp"),
+            max_files: args.log_max_files,
+            path: args.log_dir.clone(),
             filters: None,
         }
     }

--- a/based/crates/common/src/utils.rs
+++ b/based/crates/common/src/utils.rs
@@ -45,6 +45,7 @@ pub fn build_env_filter(default_level: LevelFilter, env_filters: Option<String>)
 /// Initialises tracing logger that creates daily log files.
 pub fn init_tracing(config: LoggingConfig) -> Option<WorkerGuard> {
     let format = tracing_subscriber::fmt::format().with_level(true).with_thread_ids(false).with_target(false);
+
     if config.flags == LoggingFlags::File | LoggingFlags::StdOut {
         let _ = std::fs::create_dir_all(&config.path);
         let mut builder =
@@ -58,14 +59,15 @@ pub fn init_tracing(config: LoggingConfig) -> Option<WorkerGuard> {
         let (writer, guard) = tracing_appender::non_blocking(appender);
 
         let stdout_layer = tracing_subscriber::fmt::layer()
-            .event_format(format.clone())
+            .event_format(format)
             .with_filter(build_env_filter(config.level, config.filters.clone()));
 
         let file_layer = tracing_subscriber::fmt::layer()
-            .event_format(format)
+            .event_format(tracing_subscriber::fmt::format().json())
+            .with_timer(tracing_subscriber::fmt::time::UtcTime::rfc_3339())
             .with_ansi(false)
             .with_writer(writer)
-            .with_filter(build_env_filter(config.level, config.filters.clone()));
+            .with_filter(build_env_filter(config.level, config.filters));
 
         tracing_subscriber::registry().with(stdout_layer.and_then(file_layer)).init();
 
@@ -76,7 +78,7 @@ pub fn init_tracing(config: LoggingConfig) -> Option<WorkerGuard> {
         let stdout_layer = tracing_subscriber::fmt::layer()
             .event_format(format)
             .with_writer(writer)
-            .with_filter(build_env_filter(config.level, config.filters.clone()));
+            .with_filter(build_env_filter(config.level, config.filters));
 
         tracing_subscriber::registry().with(stdout_layer).init();
         Some(guard)
@@ -93,10 +95,11 @@ pub fn init_tracing(config: LoggingConfig) -> Option<WorkerGuard> {
         let (writer, guard) = tracing_appender::non_blocking(appender);
 
         let file_layer = tracing_subscriber::fmt::layer()
-            .event_format(format)
+            .event_format(tracing_subscriber::fmt::format().json())
+            .with_timer(tracing_subscriber::fmt::time::UtcTime::rfc_3339())
             .with_ansi(false)
             .with_writer(writer)
-            .with_filter(build_env_filter(config.level, config.filters.clone()));
+            .with_filter(build_env_filter(config.level, config.filters));
 
         tracing_subscriber::registry().with(file_layer).init();
 

--- a/based/crates/metrics/src/consumer.rs
+++ b/based/crates/metrics/src/consumer.rs
@@ -10,7 +10,7 @@ use tracing::{info, trace};
 
 /// The number of units of budget to spend per loop iteration.
 /// Useful to avoid starving the consumers.
-const LOOP_BUDGET: u64 = 10_000;
+const LOOP_BUDGET: u64 = 500;
 
 /// Consumes telemetry updates from shared memory queues, and converts them into metrics.
 pub struct MetricsConsumer {

--- a/follower_node/compose.yml
+++ b/follower_node/compose.yml
@@ -42,7 +42,9 @@ services:
           --port=$OP_GETH_GOSSIP_PORT \
           --bootnodes=$MAIN_OP_GETH_ENODE \
           --rollup.sequencerhttp=$TXPROXY
-
+    labels:
+      - logs=enabled
+      - service=based-op-geth
     volumes:
       - ./data/geth:/data/geth
       - ./config:/config
@@ -84,6 +86,9 @@ services:
     depends_on:
       - based-op-geth
     restart: unless-stopped
+    labels:
+      - logs=enabled
+      - service=based-op-node
 
   based-gateway:
     image: ghcr.io/gattaca-com/based-op/based-gateway:latest

--- a/follower_node/compose.yml
+++ b/follower_node/compose.yml
@@ -98,10 +98,12 @@ services:
       - --rpc.jwt=/config/jwt
       - --gossip.signer_private_key=$GATEWAY_SEQUENCING_KEY
       - --gossip.root_peer_url=http://0.0.0.0:8547
+      - --log.dir=/var/log/app
     volumes:
       - ./config:/config
       - ./data/gateway:/data/gateway
       - /tmp:/tmp
       - /dev/shm:/dev/shm
+      - /var/log/containers/based-op/based-gateway:/var/log/app
     network_mode: "host"
     restart: unless-stopped

--- a/main_node/compose.yml
+++ b/main_node/compose.yml
@@ -42,6 +42,9 @@ services:
       - ./data/geth:/data/geth
       - ./config:/config
     restart: unless-stopped
+    labels:
+      - logs=enabled
+      - service=op-geth
 
   op-node:
     image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.2
@@ -75,7 +78,6 @@ services:
       - --p2p.sequencer.key=${OP_NODE_SEQUENCER_KEY}
       - --safedb.path=/data/op-node/op-node-beacon-data
       - --sequencer.enabled
-
     volumes:
       - ./data/node:/data/op-node
       - ./config:/config
@@ -83,6 +85,9 @@ services:
       - op-geth
       - based-portal
     restart: unless-stopped
+    labels:
+      - logs=enabled
+      - service=op-node
     
   op-batcher:
     image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:v1.13.2
@@ -109,6 +114,9 @@ services:
     depends_on:
       - op-node
     restart: unless-stopped
+    labels:
+      - logs=enabled
+      - service=op-batcher
 
   op-proposer:
     image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-proposer:v1.10.0
@@ -124,10 +132,12 @@ services:
       - --private-key=${OP_PROPOSER_PRIVATE_KEY}
       - --l1-eth-rpc=${L1_RPC_URL}
       - --proposal-interval=2s
-
     depends_on:
       - op-node
     restart: unless-stopped
+    labels:
+      - logs=enabled
+      - service=op-proposer
 
   based-portal:
     image: ghcr.io/gattaca-com/based-op/based-portal:latest 
@@ -141,8 +151,10 @@ services:
       - --op_node.url=http://0.0.0.0:${OP_NODE_RPC_PORT}
       - --registry.url=http://0.0.0.0:${REGISTRY_PORT}
       - --gateway.timeout_ms=200
+      - --log.dir=/var/log/app
     volumes:
       - ./config:/config
+      - /var/log/containers/based-op/based-portal:/var/log/app
     restart: unless-stopped
 
   based-registry:
@@ -155,8 +167,10 @@ services:
       - --registry.path=/config/registry.json
       - --eth_rpc_url=http://0.0.0.0:${OP_GETH_RPC_PORT}
       - --port=${REGISTRY_PORT}
+      - --log.dir=/var/log/app
     volumes: 
       - ./config:/config
+      - /var/log/containers/based-op/based-registry:/var/log/app
     restart: unless-stopped
     
   restarter:
@@ -174,8 +188,10 @@ services:
     command:
       - --tx_receivers.path=/config/tx_receivers.json
       - --port=${TXPROXY_PORT}
+      - --log.dir=/var/log/app
     volumes: 
       - ./config:/config
+      - /var/log/containers/based-op/based-
     restart: unless-stopped
 
 # ################################################################################

--- a/main_node/compose.yml
+++ b/main_node/compose.yml
@@ -191,7 +191,7 @@ services:
       - --log.dir=/var/log/app
     volumes: 
       - ./config:/config
-      - /var/log/containers/based-op/based-
+      - /var/log/containers/based-op/based-txproxy:/var/log/app
     restart: unless-stopped
 
 # ################################################################################

--- a/main_node/compose.yml
+++ b/main_node/compose.yml
@@ -154,6 +154,8 @@ services:
       - --log.dir=/var/log/app
     volumes:
       - ./config:/config
+      - /tmp:/tmp
+      - /dev/shm:/dev/shm
       - /var/log/containers/based-op/based-portal:/var/log/app
     restart: unless-stopped
 
@@ -170,6 +172,8 @@ services:
       - --log.dir=/var/log/app
     volumes: 
       - ./config:/config
+      - /tmp:/tmp
+      - /dev/shm:/dev/shm
       - /var/log/containers/based-op/based-registry:/var/log/app
     restart: unless-stopped
     
@@ -191,6 +195,8 @@ services:
       - --log.dir=/var/log/app
     volumes: 
       - ./config:/config
+      - /tmp:/tmp
+      - /dev/shm:/dev/shm
       - /var/log/containers/based-op/based-txproxy:/var/log/app
     restart: unless-stopped
 

--- a/monitoring/compose.yml
+++ b/monitoring/compose.yml
@@ -50,9 +50,41 @@ services:
     depends_on:
       - prometheus
 
+  promtail:
+    image: grafana/promtail:latest
+    container_name: promtail
+    restart: unless-stopped
+    ports:
+      - 9085:9085
+    environment:
+      - HOSTNAME
+    volumes:
+      - ./promtail/promtail.yml:/etc/promtail/promtail.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro # discovery
+      - /var/log/containers:/var/log/containers:ro # structured file tailing
+    command:
+      - --config.file=/etc/promtail/promtail.yml
+    networks:
+      - monitoring
+
+  loki:
+    image: grafana/loki:latest
+    container_name: loki
+    restart: unless-stopped
+    ports:
+      - 3100:3100
+    volumes:
+      - loki-data:/loki
+      - ./loki/loki.yml:/etc/loki/loki.yml:ro
+    command:
+      - --config.file=/etc/loki/loki.yml
+    networks:
+      - monitoring
+
 volumes:
   prometheus-data:
   grafana-data:
+  loki-data:
 
 networks:
   monitoring:

--- a/monitoring/grafana/datasource.yml
+++ b/monitoring/grafana/datasource.yml
@@ -7,3 +7,13 @@ datasources:
     isDefault: true
     access: proxy
     editable: false
+
+  - name: Loki
+    type: loki
+    url: http://loki:3100
+    isDefault: false
+    access: proxy
+    editable: false
+    jsonData:
+      timeout: 60
+      maxLines: 1000

--- a/monitoring/loki/loki.yml
+++ b/monitoring/loki/loki.yml
@@ -1,0 +1,37 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  storage:
+    type: local
+    local:
+      directory: /loki/rules
+  rule_path: /loki/rules-temp
+  alertmanager_url: http://localhost:9093
+  ring:
+    kvstore:
+      store: inmemory
+  enable_api: true

--- a/monitoring/promtail/promtail.yml
+++ b/monitoring/promtail/promtail.yml
@@ -64,19 +64,6 @@ scrape_configs:
             level: level
             service: service
             msg: msg
-      - labels:
-          level:
-          env:
-          service:
     relabel_configs:
-      # Extract project/service from the file path
-      - source_labels: [__path__]
-        regex: .*/([^/]+)/([^/]+)/[^/]+\.jsonl
-        target_label: project
-        replacement: $1
-      - source_labels: [__path__]
-        regex: .*/([^/]+)/([^/]+)/[^/]+\.jsonl
-        target_label: service
-        replacement: $2
       - replacement: "${HOSTNAME}"
         target_label: host

--- a/monitoring/promtail/promtail.yml
+++ b/monitoring/promtail/promtail.yml
@@ -14,12 +14,16 @@ scrape_configs:
     docker_sd_configs:
       - host: unix:///var/run/docker.sock
         refresh_interval: 5s
+        filters:
+          - name: label
+            values: ["logs=enabled"] # only discover containers with label logs=enabled
     pipeline_stages:
       - cri: {} # handles container log framing
       - json: # parse JSON logs if your app prints JSON
           expressions:
             level: level
             msg: msg
+            timestamp: timestamp
       - labels: # promote low-cardinality fields to labels
           level:
           service:
@@ -45,10 +49,21 @@ scrape_configs:
     static_configs:
       - targets: [localhost]
         labels:
-          # path format: /var/log/containers/<project>/<service>/app-*.jsonl
-          __path__: /var/log/containers/*/*/*.jsonl # rotate-friendly glob
+          # path format: /var/log/containers/<project>/<service>/app-*.log.2025-08-27
+          __path__: /var/log/containers/*/*/*.log* # rotate-friendly glob
     pipeline_stages:
-      - json: {}
+      # derive labels from the real file path (the 'filename' label)
+      - regex:
+          source: filename
+          expression: '.*/(?P<project>[^/]+)/(?P<service>[^/]+)/[^/]+\.log\.[0-9]{4}-[0-9]{2}-[0-9]{2}$'
+      - labels:
+          project:
+          service:
+      - json:
+          expressions:
+            level: level
+            service: service
+            msg: msg
       - labels:
           level:
           env:

--- a/monitoring/promtail/promtail.yml
+++ b/monitoring/promtail/promtail.yml
@@ -1,0 +1,67 @@
+server:
+  http_listen_port: 9085
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  # docker containers with label logs=enabled
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    pipeline_stages:
+      - cri: {} # handles container log framing
+      - json: # parse JSON logs if your app prints JSON
+          expressions:
+            level: level
+            msg: msg
+      - labels: # promote low-cardinality fields to labels
+          level:
+          service:
+          env:
+    relabel_configs:
+      # keep only containers with label logs=enabled
+      - source_labels: [__meta_docker_container_label_logs]
+        regex: "enabled"
+        action: keep
+      # set job label from docker label "service"
+      - source_labels: [__meta_docker_container_label_service]
+        target_label: job
+      # handy default labels from docker metadata
+      - source_labels: [__meta_docker_container_name]
+        target_label: container
+      - source_labels: [__meta_docker_container_image]
+        target_label: image
+      - source_labels: [__meta_docker_container_label_env]
+        target_label: env
+
+  # structured files from containers on /var/log/containers
+  - job_name: container_files
+    static_configs:
+      - targets: [localhost]
+        labels:
+          # path format: /var/log/containers/<project>/<service>/app-*.jsonl
+          __path__: /var/log/containers/*/*/*.jsonl # rotate-friendly glob
+    pipeline_stages:
+      - json: {}
+      - labels:
+          level:
+          env:
+          service:
+    relabel_configs:
+      # Extract project/service from the file path
+      - source_labels: [__path__]
+        regex: .*/([^/]+)/([^/]+)/[^/]+\.jsonl
+        target_label: project
+        replacement: $1
+      - source_labels: [__path__]
+        regex: .*/([^/]+)/([^/]+)/[^/]+\.jsonl
+        target_label: service
+        replacement: $2
+      - replacement: "${HOSTNAME}"
+        target_label: host


### PR DESCRIPTION
Current stack:
* #216 
* #215 
* #207 

This PR adds Promtail and Loki for structured log export.

The rationale with this setup is to ALWAYS try to output pretty logs to stdout, and only output structured JSON files
if supported by the binary. This allows for easier debugging without having to read/parse JSON manually every time.

Rules are setup such that every container in the main/gateway configuration will either: 
* provide a `logs=enabled` docker label, signaling to be auto-scraped (with discovery via `docker.sock`)
* provide JSONL format files in `/var/log/containers` (with file path also specifying a `<project>` and `<service>`).

