### PR TITLE
fix: use DisputeGameFactory proxy address rather than implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,7 @@ start-main-node: create-network
 	  $(MAKE) fix-compose; \
 	  echo "Initializing all components of a main sequencing node in ./.local_main_node ..."; \
 	  { \
-	    echo "DISPUTE_GAME_FACTORY_ADDRESS=$$(docker run -v $$(pwd)/.local_main_node/config:/config -i --rm imega/jq -r '.implementationsDeployment.disputeGameFactoryImplAddress' /config/state.json)"; \
+	    echo "DISPUTE_GAME_FACTORY_ADDRESS=$$(docker run -v $$(pwd)/.local_main_node/config:/config -i --rm imega/jq -r '.opChainDeployments[0].disputeGameFactoryProxyAddress' /config/state.json)"; \
 	    echo "NETWORK_ID=$$(docker run -v $$(pwd)/.local_main_node/config:/config -i --rm imega/jq -r '.l2_chain_id' /config/rollup.json)"; \
 	    echo "L1_RPC_URL=$(L1_RPC_URL)"; \
 	    echo "L1_BEACON_RPC_URL=$(L1_BEACON_RPC_URL)"; \


### PR DESCRIPTION
hey, i noticed that the op-proposer logs were composed of cycles like this:

```
op-proposer  | t=2025-09-05T09:04:31+0000 lvl=info msg="No proposals found for at least proposal interval, submitting proposal now" proposalInterval=2s
op-proposer  | t=2025-09-05T09:04:31+0000 lvl=info msg="Proposing output root" output=0x512f882d2c20682d9f172ce7c6390dc5d60bc1359fafe30cdd3a74018006bcfd block=78494
op-proposer  | t=2025-09-05T09:04:31+0000 lvl=warn msg="Failed to create a transaction, will retry" service=proposer err="failed to estimate gas: execution reverted, reason: 0x031c6de40000000000000000000000000000000000000000000000000000000000000001"
op-proposer  | t=2025-09-05T09:04:33+0000 lvl=warn msg="Failed to create a transaction, will retry" service=proposer err="failed to estimate gas: execution reverted, reason: 0x031c6de40000000000000000000000000000000000000000000000000000000000000001"
[ retry 30 times omitted ]
```

after some inspection, i noticed that the DISPUTE_GAME_FACTORY_ADDRESS of `.local_main_node/.env` was set to the implementation rather than the proxy address.

this PR edits the `jq` command to get the proxy address from `state.json`.