### PR TITLE
fix(sequencer): when sealing frag, ensure the last simulated tx is applied

### DIFF
--- a/based/crates/sequencer/src/lib.rs
+++ b/based/crates/sequencer/src/lib.rs
@@ -107,8 +107,8 @@ where
 
         // handle new transaction
         connections.receive_for(Duration::from_millis(10), |msg, senders| {
-            if self.data.timestamp() != 0 &&
-                self.supervisor.as_ref().is_some_and(|validator| !validator.is_valid(&msg, self.data.timestamp()))
+            if self.data.timestamp() != 0
+                && self.supervisor.as_ref().is_some_and(|validator| !validator.is_valid(&msg, self.data.timestamp()))
             {
                 return;
             }
@@ -551,7 +551,10 @@ impl<Db: Clone + DatabaseRef> SequencerState<Db> {
         use SequencerState::*;
         let base_fee = data.as_ref().basefee;
         match self {
-            Sorting(mut seq, sorting_data) if sorting_data.should_seal_frag() => {
+            Sorting(mut seq, mut sorting_data) if sorting_data.should_seal_frag() => {
+                // There might still be left over tx to apply from a previous completed simulation.
+                sorting_data.maybe_apply(base_fee);
+
                 data.timers.waiting_for_sims.stop();
                 data.timers.seal_frag.start();
                 // Reset the tx pool.


### PR DESCRIPTION
When handling a simulation (`SortingData::handle_sim`), in the happy scenario the simulated transaction is added as next_to_be_applied. https://github.com/gattaca-com/based-op/blob/lore%2Ffeat%2Fchain-replay/based/crates/sequencer/src/sorting/sorting_data.rs#L238-L241.  

If that happens right before we have to seal a frag, the current code forget to apply that tx, and then after seal_frag concludes we have new `SortingData`, effectively losing that simulated transaction indefinitely. Here, the main fix I see is just adding another `sorting_data.maybe_apply(base_fee);` before the call to seal_frag.