### PR TITLE
feat(sequencer): fifo ordering

### DIFF
--- a/based/crates/common/src/config.rs
+++ b/based/crates/common/src/config.rs
@@ -56,6 +56,10 @@ pub struct GatewayArgs {
     /// Number of sims per loop
     #[arg(long = "sequencer.sim_threads", default_value_t = 5)]
     pub sim_threads: usize,
+    /// Run the sequencer in fifo ordering mode. Note that this will result in using only one
+    /// simulation thread. This must be used for chain replication testing.
+    #[arg(long = "sequencer.fifo_ordering", default_value_t = false)]
+    pub fifo_ordering: bool,
     /// vsync window in micros
     #[arg(long = "sequencer.vsync_window_us", default_value_t = 10)]
     pub vsync_window_us: usize,

--- a/based/crates/sequencer/src/config.rs
+++ b/based/crates/sequencer/src/config.rs
@@ -26,6 +26,7 @@ impl From<&GatewayArgs> for SuperVisorConfig {
 pub struct SequencerConfig {
     pub frag_duration: Duration,
     pub n_per_loop: usize,
+    pub fifo_ordering: bool,
     pub rpc_url: Url,
     pub evm_config: OpEvmConfig,
     /// If true, we will simulate txs at the top of each frag in the pools.
@@ -40,7 +41,8 @@ impl From<&GatewayArgs> for SequencerConfig {
     fn from(args: &GatewayArgs) -> Self {
         Self {
             frag_duration: Duration::from_millis(args.frag_duration_ms),
-            n_per_loop: args.sim_threads,
+            n_per_loop: if args.fifo_ordering { 1 } else { args.sim_threads },
+            fifo_ordering: args.fifo_ordering,
             rpc_url: args.eth_client_url.clone(),
             simulate_tof_in_pools: false,
             evm_config: OpEvmConfig::new(args.chain.clone(), Default::default()),

--- a/based/crates/sequencer/src/sorting/frag_sequence.rs
+++ b/based/crates/sequencer/src/sorting/frag_sequence.rs
@@ -161,6 +161,7 @@ mod tests {
 
         let config = SequencerConfig {
             frag_duration: Duration::from_millis(200),
+            fifo_ordering: false,
             n_per_loop: 5,
             rpc_url: rpc_url.clone(),
             evm_config: evm_config.clone(),

--- a/based/crates/sequencer/src/sorting/mod.rs
+++ b/based/crates/sequencer/src/sorting/mod.rs
@@ -58,17 +58,20 @@ impl ActiveOrders {
         unreachable!("this should never happen");
     }
 
-    pub fn put(&mut self, tx: SimulatedTx) {
-        let payment = tx.payment;
+    pub fn put(&mut self, tx: SimulatedTx, fifo_ordering: bool) {
         let mut id = self.orders.len();
-        let sender = tx.sender();
-        for (i, order) in self.orders.iter_mut().enumerate().rev() {
-            if order.sender() == sender {
-                order.put(tx);
-                return;
-            }
-            if payment < order.payment() {
-                id = i;
+
+        if !fifo_ordering {
+            let payment = tx.payment;
+            let sender = tx.sender();
+            for (i, order) in self.orders.iter_mut().enumerate().rev() {
+                if order.sender() == sender {
+                    order.put(tx);
+                    return;
+                }
+                if payment < order.payment() {
+                    id = i;
+                }
             }
         }
         // not found so we insert it at the id corresponding to the payment

--- a/based/crates/sequencer/src/sorting/sorting_data.rs
+++ b/based/crates/sequencer/src/sorting/sorting_data.rs
@@ -103,6 +103,8 @@ pub struct SortingData<Db> {
     /// We wait until these are back before we apply the next
     /// and send the next round of simulations
     pub in_flight_sims: usize,
+    /// Whether we should use fifo ordering instead of sorting by payments value.
+    pub fifo_ordering: bool,
     /// Remaining orders to be sorted, ideally with top of frag (TOF)
     /// sim data. The TOF sim data can be used as a heuristic initial sort of
     /// the orders. The assumption is that applying some orders will not
@@ -160,6 +162,7 @@ impl<Db: DatabaseRead> SortingData<Db> {
             gas_remaining: seq.gas_remaining,
             da_config: data.config.da_config.clone(),
             da_remaining: seq.da_remaining,
+            fifo_ordering: data.config.fifo_ordering,
             txs: vec![],
             start_t: Instant::now(),
             telemetry: Default::default(),
@@ -235,15 +238,16 @@ impl<Db> SortingData<Db> {
             &mut self.metrics_producer,
         );
 
-        let tx_to_put_back = if simulated_tx.gas_used() < self.gas_remaining &&
-            self.next_to_be_applied.as_ref().is_none_or(|t| t.payment < simulated_tx.payment)
+        let tx_to_put_back = if simulated_tx.gas_used() < self.gas_remaining
+            && self.next_to_be_applied.as_ref().is_none_or(|t| t.payment < simulated_tx.payment)
+            && !self.fifo_ordering
         {
             self.next_to_be_applied.replace(simulated_tx)
         } else {
             Some(simulated_tx)
         };
         if let Some(tx) = tx_to_put_back {
-            self.tof_snapshot.put(tx)
+            self.tof_snapshot.put(tx, self.fifo_ordering)
         }
     }
 

--- a/based/crates/sequencer/src/sorting/sorting_data.rs
+++ b/based/crates/sequencer/src/sorting/sorting_data.rs
@@ -238,9 +238,9 @@ impl<Db> SortingData<Db> {
             &mut self.metrics_producer,
         );
 
-        let tx_to_put_back = if simulated_tx.gas_used() < self.gas_remaining
-            && self.next_to_be_applied.as_ref().is_none_or(|t| t.payment < simulated_tx.payment)
-            && !self.fifo_ordering
+        let tx_to_put_back = if simulated_tx.gas_used() < self.gas_remaining &&
+            self.next_to_be_applied.as_ref().is_none_or(|t| t.payment < simulated_tx.payment) &&
+            !self.fifo_ordering
         {
             self.next_to_be_applied.replace(simulated_tx)
         } else {


### PR DESCRIPTION
Introduces a new flag for running the sequencer info fifo ordering mode, meaning that txs are included in the order they're received from the `eth_sendRawTransaction` endpoint on the gateway.

This has been successfully tested with chain replication based on #225 on blocks `3435715..=3437082` (1368 blocks) on based-op-sepolia which feature spamoor load. 

