### PR TITLE
improve frag scheduling

### DIFF
--- a/based/crates/common/src/time/types/duration.rs
+++ b/based/crates/common/src/time/types/duration.rs
@@ -31,7 +31,7 @@ impl Duration {
 
     #[inline]
     pub fn from_secs_f64(s: f64) -> Self {
-        Self::from_secs((s * 1_000_000_000.0).round() as u64)
+        Self::from_nanos((s * 1_000_000_000.0).round() as u64)
     }
 
     #[inline]

--- a/based/crates/sequencer/src/context.rs
+++ b/based/crates/sequencer/src/context.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, fmt::Display, sync::Arc};
+use std::{collections::VecDeque, fmt::Display, sync::{Arc}, time::Instant};
 
 use alloy_consensus::{BlockHeader, EMPTY_OMMER_ROOT_HASH, Header};
 use alloy_eips::merge::BEACON_NONCE;
@@ -79,6 +79,7 @@ pub struct SequencerContext<Db> {
     pub timers: SequencerTimers,
     pub telemetry: Producer<TelemetryUpdate>,
     pub metrics: Producer<MetricsUpdate>,
+    pub last_seal_time: Instant,
 }
 
 impl<Db: DatabaseRead> SequencerContext<Db> {
@@ -104,6 +105,7 @@ impl<Db: DatabaseRead> SequencerContext<Db> {
             base_fee: Default::default(),
             timers: Default::default(),
             telemetry: telemetry_queue().into(),
+            last_seal_time: Instant::now(),
         }
     }
 }

--- a/based/crates/sequencer/src/lib.rs
+++ b/based/crates/sequencer/src/lib.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Instant};
 
 use alloy_consensus::BlockHeader;
 use alloy_eips::eip7685::RequestsOrHash;
@@ -409,6 +409,7 @@ where
                 ctx.timers.seal_block.start();
 
                 // Gossip last frag before sealing
+                ctx.last_seal_time = Instant::now();
                 let (last_frag, maybe_state) = ctx.seal_last_frag(&mut seq, sorting_data);
                 let msg =
                     VersionedMessageWithState { msg: VersionedMessage::from(last_frag), state_update: maybe_state };
@@ -562,6 +563,7 @@ impl<Db: Clone + DatabaseRef + DatabaseRead> SequencerState<Db> {
                 data.timers.waiting_for_sims.stop();
                 data.timers.seal_frag.start();
 
+                data.last_seal_time = Instant::now();
                 let (msg, maybe_update, new_sort_dat) = data.seal_frag(sorting_data, &mut seq);
                 let versioned_message = VersionedMessage::from(msg);
                 connections.send(VersionedMessageWithState { msg: versioned_message, state_update: maybe_update });

--- a/based/crates/sequencer/src/sorting/sorting_data.rs
+++ b/based/crates/sequencer/src/sorting/sorting_data.rs
@@ -152,9 +152,12 @@ impl<Db: DatabaseRead> SortingData<Db> {
 
         debug!(da_remaining = seq.da_remaining, gas_remaining = seq.gas_remaining, "new sorting data created");
 
+        let since_last_seal = data.last_seal_time.elapsed().into();
+        let adjusted_frag_time = data.config.frag_duration.saturating_sub(since_last_seal).max(Duration::from_millis(50));
+
         Self {
             db,
-            until: Instant::now() + data.config.frag_duration,
+            until: Instant::now() + adjusted_frag_time,
             in_flight_sims: 0,
             payment: U256::ZERO,
             next_to_be_applied: None,
@@ -238,9 +241,9 @@ impl<Db> SortingData<Db> {
             &mut self.metrics_producer,
         );
 
-        let tx_to_put_back = if simulated_tx.gas_used() < self.gas_remaining &&
-            self.next_to_be_applied.as_ref().is_none_or(|t| t.payment < simulated_tx.payment) &&
-            !self.fifo_ordering
+        let tx_to_put_back = if simulated_tx.gas_used() < self.gas_remaining
+            && self.next_to_be_applied.as_ref().is_none_or(|t| t.payment < simulated_tx.payment)
+            && !self.fifo_ordering
         {
             self.next_to_be_applied.replace(simulated_tx)
         } else {


### PR DESCRIPTION
Because the OP node can take a variable amount of time to send `NewPayload` after `GetPayload`, if we keep constant frag time it would affect disproportionately users sending transactions towards the end of block (frag_time + sealing / op node overhead). To keep frags more consistent in time, we keep track of when last frag was sealed and may seal the first frag in the new block earlier to account for that 