### PR TITLE
fix: TxList bug

### DIFF
--- a/based/crates/common/src/transaction/tx_list.rs
+++ b/based/crates/common/src/transaction/tx_list.rs
@@ -49,12 +49,12 @@ impl TxList {
         if self.txs.front().is_some_and(|t| t.nonce() > nonce) {
             return false;
         }
-        while let Some(t) = self.txs.pop_front() {
-            if t.nonce() == nonce {
-                f(t);
+        while let Some(tx) = self.txs.pop_front() {
+            if tx.nonce() > nonce {
+                self.txs.push_front(tx);
                 break;
             }
-            f(t);
+            f(tx);
         }
         self.is_empty()
     }


### PR DESCRIPTION
If there is a gap in the txlist where there is no t.nonce() == nonce but some t.nonce() > nonce, the whole list is still drained. That is fixed in this PR.